### PR TITLE
Allow usage of any custom attribute (a=...)

### DIFF
--- a/src/javaforce/voip/SDP.java
+++ b/src/javaforce/voip/SDP.java
@@ -125,6 +125,7 @@ public class SDP implements Cloneable {
   public String owner;
   public String session;
   public long time_start, time_stop;
+  public List<String> otherAttributes = new ArrayList<String>();
 
   public Stream addStream(Type type) {
     JFLog.log(log, "SDP.addStream:" + type);

--- a/src/javaforce/voip/SIP.java
+++ b/src/javaforce/voip/SIP.java
@@ -663,6 +663,9 @@ public abstract class SIP {
           byte salt[] = Arrays.copyOfRange(keys, 16, 16 + 14);
           stream.addKey(f[1], key, salt);
         }
+        else {
+	      sdp.otherAttributes.add(ln.substring(2));
+        }
       }
       else if (ln.startsWith("o=")) {
         //o=- {count} {count} IN IP4 {host}


### PR DESCRIPTION
Hello,

for my SIP demo application I need different attributes than already implemented in javaforce (and not all attributes are finally specified yet).

To go ahead, I added a array list called "otherAttributes" to the SDP class.
The array list is filled in the SIP class if the attribute is not recognized as one of your specific attributes.
This also means that there is a final else to the if-elseif-structure and no data is discarded any more.

I also considered putting all attributes in a list or dictionary type, but that was too invasiv from my point of few.
Also I was not sure on how to name the list: otherAttributes, unknownAttributes, ...

Looking forward to hearing from you.
Ideas, suggestions, improvements are welcome! :)

Best regards, Tobias